### PR TITLE
Match navbar and article-list widths on all screens

### DIFF
--- a/blog/.vitepress/theme/components/ArticleCardList.vue
+++ b/blog/.vitepress/theme/components/ArticleCardList.vue
@@ -1,10 +1,14 @@
-<script setup>
+<script setup lang="ts">
   import ArticleCard from './ArticleCard.vue'
   import { data as articles } from './../index.data.ts'
+
+  const props = defineProps<{
+    classes?: string,
+  }>()
 </script>
 
 <template>
-  <div class="flex flex-wrap justify-center gap-y-4 w-full">
+  <div class="flex flex-wrap justify-center gap-y-4 w-full" :class="classes">
     <ArticleCard
       v-for="article in articles"
       :title="article.title"

--- a/blog/.vitepress/theme/css/style.css
+++ b/blog/.vitepress/theme/css/style.css
@@ -501,3 +501,20 @@
   /* Hide as it clips the footer on scroll */
   display: none;
 }
+
+.vitepress-max-width {
+  max-width: calc(var(--vp-layout-max-width) - 64px);
+}
+
+.VPNavBar {
+  @apply !pl-0;
+  @media screen(sm) {
+    @apply !pr-4;
+  }
+  @media screen(lg) {
+    @apply !px-4;
+  }
+  @media screen(2xl) {
+    @apply !px-0;
+  }
+}

--- a/blog/.vitepress/theme/css/style.css
+++ b/blog/.vitepress/theme/css/style.css
@@ -506,15 +506,27 @@
   max-width: calc(var(--vp-layout-max-width) - 64px);
 }
 
-.VPNavBar {
-  @apply !pl-0;
+.VPNav .VPNavBar {
+  @apply px-0;
   @media screen(sm) {
-    @apply !pr-4;
+    @apply pr-4;
   }
   @media screen(lg) {
-    @apply !px-4;
+    @apply pl-0;
+    @apply pr-4;
   }
   @media screen(2xl) {
-    @apply !px-0;
+    @apply px-0;
   }
+
+  .container {
+    @apply max-w-full;
+
+    @media screen(2xl) {
+      max-width: calc(var(--vp-layout-max-width) - 64px);
+    }
+  }
+}
+.VPNavBar .VPNavBarHamburger {
+  width: 60px;
 }

--- a/blog/index.md
+++ b/blog/index.md
@@ -5,6 +5,6 @@ title: Musings on SaaS pricing, subscription strategy, and code
 description: The official Planship blog
 ---
 
-<div class="px-1 md:px-6 lg:px-12 xl:px-20 py-4">
-  <ArticleCardList />
+<div class="flex justify-center md:px-4 py-4">
+  <ArticleCardList classes="vitepress-max-width" />
 </div>


### PR DESCRIPTION
This PR, when merged, matches the widths of the navbar and articles list. It's a little fragile as it has to work with the default theme's styles (E.g. `max-width` calculation for the navbar).