### PR TITLE
Fix underlying html issues in navbar to address hydration mismatch error

### DIFF
--- a/blog/.vitepress/config.mts
+++ b/blog/.vitepress/config.mts
@@ -143,6 +143,12 @@ export default defineConfig({
           replacement: fileURLToPath(
             new URL('./theme/components/Footer.vue', import.meta.url)
           )
+        },
+        {
+          find: /^.*\/VPNavBarTitle\.vue$/,
+          replacement: fileURLToPath(
+            new URL('./theme/components/NavBarTitle.vue', import.meta.url)
+          )
         }
       ]
     }

--- a/blog/.vitepress/theme/components/Footer.vue
+++ b/blog/.vitepress/theme/components/Footer.vue
@@ -16,7 +16,7 @@
   >
     <div class="container">
       <a href="https://planship.io">
-        <img class="w-20 h-20 m-auto" src="/planship-logo-inward-square.svg" />
+        <img class="w-20 h-20 m-auto" src="/planship-logo-inward-square.svg" alt="Planship logo depicting a cargo ship with a crane hoisting a shipping container">
         <h3 class="text-4xl font-extrabold bg-gradient-to-b from-jordy-blue-500 to-shamrock-400 inline-block text-transparent bg-clip-text">
           Planship
         </h3>

--- a/blog/.vitepress/theme/components/Logo.vue
+++ b/blog/.vitepress/theme/components/Logo.vue
@@ -6,7 +6,7 @@
     <img
       class="VPImage logo !m-0"
       src="/planship-logo.svg"
-      alt="Illustration of a ship with a crane hoisting a shipping container"
+      alt="Planship logo depicting a cargo ship with a crane hoisting a shipping container"
     />
   </a>
 </template>

--- a/blog/.vitepress/theme/components/NavBarTitle.vue
+++ b/blog/.vitepress/theme/components/NavBarTitle.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+  /*
+    Replacement for VPNavBarTitle
+    https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/components/VPNavBarTitle.vue
+  */
+  import { useSidebar } from 'vitepress/theme'
+
+  const { hasSidebar } = useSidebar()
+</script>
+
+<template>
+  <div class="VPNavBarTitle" :class="{ 'has-sidebar': hasSidebar }">
+    <div class="title">
+      <slot name="nav-bar-title-before" />
+      <slot name="nav-bar-title-after" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .title {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid transparent;
+    width: 100%;
+    height: var(--vp-nav-height);
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--vp-c-text-1);
+    transition: opacity 0.25s;
+  }
+
+  @media (min-width: 960px) {
+    .title {
+      flex-shrink: 0;
+    }
+
+    .VPNavBarTitle.has-sidebar .title {
+      border-bottom-color: var(--vp-c-divider);
+    }
+  }
+
+  :deep(.logo) {
+    margin-right: 8px;
+    height: var(--vp-nav-logo-height);
+  }
+</style>

--- a/blog/.vitepress/theme/components/SiteTitle.vue
+++ b/blog/.vitepress/theme/components/SiteTitle.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+  import { useData } from 'vitepress'
+  const { theme } = useData()
+</script>
+
+<template>
+  <a class="title" href="/"><span>{{ theme.siteTitle }}</span></a>
+</template>

--- a/blog/.vitepress/theme/css/style.css
+++ b/blog/.vitepress/theme/css/style.css
@@ -526,6 +526,10 @@
       max-width: calc(var(--vp-layout-max-width) - 64px);
     }
   }
+
+  .wrapper {
+    padding: 0;
+  }
 }
 .VPNavBar .VPNavBarHamburger {
   width: 60px;

--- a/blog/.vitepress/theme/index.ts
+++ b/blog/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import ArticleHeader from './components/ArticleHeader.vue'
 import CtaButton from './components/CtaButton.vue'
 import Divider from './components/Divider.vue'
 import Logo from './components/Logo.vue'
+import SiteTitle from './components/SiteTitle.vue'
 import './css/style.css'
 
 export default {
@@ -14,6 +15,7 @@ export default {
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
       'nav-bar-title-before': () => h(Logo),
+      'nav-bar-title-after': () => h(SiteTitle),
       'nav-bar-content-after': () => h(CtaButton, { classes: 'ml-4 hidden md:block' }),
       'nav-screen-content-after': () => h(CtaButton, { classes: 'mt-4 w-full inline-block' }),
       'footer-before': () => h(Divider),


### PR DESCRIPTION
This PR addresses a hydration mismatch error caused by an underlying HTML issue in the navbar. Basically, we had a nested `a` element within another `a`. Closes #9.